### PR TITLE
Add <guid> tag to RSS feed items

### DIFF
--- a/htdocs/thtml/tumble_item_image.txml
+++ b/htdocs/thtml/tumble_item_image.txml
@@ -1,6 +1,7 @@
         <item>
             <title><!-- tmpl_var name="title" --></title>
             <link><!-- tmpl_var name="url" --></link>
+            <guid>tumble-<!-- tmpl_var name="ircLinkID" --></guid>
             <description><!-- tmpl_var name="content" --></description>
             <pubDate><!-- tmpl_var name="timestamp" --></pubDate>
         </item>

--- a/htdocs/thtml/tumble_item_ircLink.txml
+++ b/htdocs/thtml/tumble_item_ircLink.txml
@@ -1,6 +1,7 @@
         <item>
             <title><!-- tmpl_var name="title" --></title>
             <link>http://<!-- tmpl_var name="baseurl" -->/irclink/?<!-- tmpl_var name="ircLinkID" --></link>
+            <guid>tumble-<!-- tmpl_var name="ircLinkID" --></guid>
             <description><!-- tmpl_var name="content" --></description>
             <pubDate><!-- tmpl_var name="timestamp" --></pubDate>
         </item>

--- a/htdocs/thtml/tumble_item_quote.txml
+++ b/htdocs/thtml/tumble_item_quote.txml
@@ -1,6 +1,7 @@
         <item>
             <title><!-- tmpl_var name="quote" --></title>
             <link>http://<!-- tmpl_var name="baseurl" -->/</link>
+            <guid>tumble-<!-- tmpl_var name="ircLinkID" --></guid>
             <description>"<!-- tmpl_var name="quote" -->" --<!-- tmpl_var name="author" --></description>
             <pubDate><!-- tmpl_var name="timestamp" --></pubDate>
         </item>


### PR DESCRIPTION
Not having this makes de-duplication in most feed readers super annoying. I keep getting Georgia Guidestoned.

Reference: http://www.landofcode.com/rss-reference/guid-tag.php
