### PR TITLE
ci: trigger deploy on production branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     branches:
-      - tumble-dark
+      - production
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary
- Update deploy workflow to trigger on `production` branch instead of `tumble-dark`
- The `tumble-dark` branch has been merged into `production`, so deploys should now run when `production` is updated

## Test plan
- [x] Verify the deploy workflow triggers on a push to `production`
- [x] Verify the deploy workflow no longer triggers on `tumble-dark`