### PR TITLE
feat: make site wordmark configurable via site_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ port: 8080
 baseurl: your.domain.com
 ```
 
+### Site Branding
+
+`site_name` sets the wordmark shown in the masthead and page titles (e.g.
+`tumblefish.stats`). It is independent of the RSS `site_title` below.
+
+```yaml
+site_name: "tumblefish"
+```
+
 ### RSS Feed Settings
 
 These optional fields customize the RSS feed metadata. If omitted, the feed title and description default to "tumble", and the other fields are omitted from the feed entirely.
@@ -86,6 +95,7 @@ Override any config value with the `TUMBLE_` prefix. Use underscores for nested 
 | `TUMBLE_REQUEST_TIMEOUT` | HTTP request timeout | `2s` |
 | `TUMBLE_ADMIN_SECRET` | Secret for admin API operations | |
 | `TUMBLE_CLICK_SIGNING_KEY` | Secret for signed click tracking | |
+| `TUMBLE_SITE_NAME` | Wordmark in masthead and page titles | `tumblefish` |
 | `TUMBLE_SITE_TITLE` | RSS feed title | `tumble` |
 | `TUMBLE_SITE_DESCRIPTION` | RSS feed description | same as title |
 | `TUMBLE_MANAGING_EDITOR` | RSS managingEditor field | omitted |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	Logging         Logging       `yaml:"logging" mapstructure:"logging"`
 	Caching         Caching       `yaml:"caching" mapstructure:"caching"`
 	RequestTimeout  time.Duration `yaml:"request_timeout" mapstructure:"request_timeout"`
+	SiteName        string        `yaml:"site_name" mapstructure:"site_name"`
 	SiteTitle       string        `yaml:"site_title" mapstructure:"site_title"`
 	SiteDescription string        `yaml:"site_description" mapstructure:"site_description"`
 	ManagingEditor  string        `yaml:"managing_editor" mapstructure:"managing_editor"`
@@ -51,6 +52,7 @@ func Load(path string) (*Config, error) {
 	v.SetDefault("logging.output", "stdout")
 	v.SetDefault("caching.enabled", true)
 	v.SetDefault("request_timeout", "2s")
+	v.SetDefault("site_name", "tumblefish")
 
 	// Environment Variables
 	v.SetEnvPrefix("TUMBLE")

--- a/internal/templates/renderer.go
+++ b/internal/templates/renderer.go
@@ -85,12 +85,28 @@ func NewRenderer(cfg *config.Config) (*Renderer, error) {
 	return r, nil
 }
 
+// htmlFuncMap returns the HTML template funcs plus config-backed helpers that
+// need to close over the renderer's config (e.g. siteName).
+func (r *Renderer) htmlFuncMap() template.FuncMap {
+	fm := template.FuncMap{}
+	for k, v := range templateFuncs {
+		fm[k] = v
+	}
+	// siteName is the configurable wordmark shown in page titles and the
+	// masthead. Defaults to "tumblefish" via config.
+	fm["siteName"] = func() string {
+		return r.cfg.SiteName
+	}
+	return fm
+}
+
 func (r *Renderer) parseTemplates() error {
 	var err error
+	htmlFuncs := r.htmlFuncMap()
 	// Determine source: Embed or Filesystem based on embed_assets config
 	if r.cfg.EmbedAssets {
 		// Use embedded FS (default for production deployments)
-		r.htmlTmpls, err = template.New("").Funcs(templateFuncs).ParseFS(viewsFS, "views/*.html")
+		r.htmlTmpls, err = template.New("").Funcs(htmlFuncs).ParseFS(viewsFS, "views/*.html")
 		if err != nil {
 			return err
 		}
@@ -101,7 +117,7 @@ func (r *Renderer) parseTemplates() error {
 	} else {
 		// Parse from local filesystem for hot-reload during development
 		// Assumes running from project root
-		r.htmlTmpls, err = template.New("").Funcs(templateFuncs).ParseGlob("internal/templates/views/*.html")
+		r.htmlTmpls, err = template.New("").Funcs(htmlFuncs).ParseGlob("internal/templates/views/*.html")
 		if err != nil {
 			return err
 		}

--- a/internal/templates/views/header.html
+++ b/internal/templates/views/header.html
@@ -227,7 +227,7 @@
         <a href="/api/docs">api docs</a>
     </div>
 
-    <a href="/" class="mobile-site-name" onclick="event.preventDefault(); window.location = window.location.origin + '/';">tumblefish.</a>
+    <a href="/" class="mobile-site-name" onclick="event.preventDefault(); window.location = window.location.origin + '/';">{{siteName}}.</a>
 
     <div class="nav-right">
         <!-- Hot Shit Dropdown -->

--- a/internal/templates/views/index.html
+++ b/internal/templates/views/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
   <head>
-    <title>tumblefish.{{.PageTitle}}</title>
+    <title>{{siteName}}.{{.PageTitle}}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" id="favicon" href="/favicon.ico" type="image/x-icon" />
     <link
@@ -648,7 +648,7 @@
 {{template "header" .}}
     <div id="page">
       <div id="masthead">
-        <a href="/" onclick="event.preventDefault(); window.location = window.location.origin + '/';">tumblefish.</a>
+        <a href="/" onclick="event.preventDefault(); window.location = window.location.origin + '/';">{{siteName}}.</a>
       </div>
 
       <div id="sidebar">

--- a/internal/templates/views/link_posted.html
+++ b/internal/templates/views/link_posted.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
-    <title>tumblefish link posted</title>
+    <title>{{siteName}} link posted</title>
     <meta http-equiv="Refresh" content="5; URL={{.RedirectURL}}" />
     <link rel="stylesheet" href="/css/screen.css" media="screen" />
 </head>

--- a/internal/templates/views/quote_permalink.html
+++ b/internal/templates/views/quote_permalink.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
   <head>
-    <title>tumblefish.{{.PageTitle}}</title>
+    <title>{{siteName}}.{{.PageTitle}}</title>
     <link
       rel="stylesheet"
       href="/css/screen.css"
@@ -53,7 +53,7 @@
 {{template "header" .}}
     <div id="page">
       <div id="masthead">
-        <a href="/" onclick="event.preventDefault(); window.location = window.location.origin + '/';">tumblefish.</a>
+        <a href="/" onclick="event.preventDefault(); window.location = window.location.origin + '/';">{{siteName}}.</a>
       </div>
 
       <div id="content" style="max-width: 600px; margin: 40px auto;">

--- a/internal/templates/views/stats.html
+++ b/internal/templates/views/stats.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
-    <title>tumblefish.stats</title>
+    <title>{{siteName}}.stats</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
     <link rel="stylesheet" href="/css/screen.css" type="text/css" media="screen" />
     {{if .CanonicalURL}}<link rel="canonical" href="{{.CanonicalURL}}" />{{end}}


### PR DESCRIPTION
## Summary

The `tumblefish` wordmark was hardcoded in page titles and the masthead
across five templates. This makes it a config value.

- New `site_name` config field (`TUMBLE_SITE_NAME`), default `"tumblefish"`
- Exposed to HTML templates via a `siteName` helper that closes over config
  in `renderer.go` — reaches both the shared `header.html` partial and the
  per-page `<title>`s from a single config read, no handler data-struct
  changes
- Replaced the hardcoded string in `header.html`, `index.html`,
  `quote_permalink.html`, `stats.html`, `link_posted.html`

## Behavior

- **Unset = identical to today**: defaults to `tumblefish`, so existing
  deployments render exactly as before.
- **Independent of RSS `site_title`**: the visible brand and the feed title
  can differ, preserving the current split (masthead `tumblefish` vs RSS
  fallback `tumble`).

## Verification

- `gofmt` clean, `git diff --check` clean, `make build` succeeds, all test
  packages pass
- Default render → `tumblefish.stats` / masthead `tumblefish.` (unchanged)
- `TUMBLE_SITE_NAME=linkfish` → `linkfish.stats` / masthead `linkfish.`,
  RSS channel title unaffected